### PR TITLE
Fixed Screenshots heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ C:\Users\[Username]\.PhpStorm\config\colors
 Windows users should have the consolas font already. Mac users (and possibly Linux?) follow this guide: http://ikato.com/blog/how-to-install-consolas-font-on-mac-os-x.html
 
 
-### Screenshots
+### Screenshots
 
 #### PHP
 


### PR DESCRIPTION
For some reason, "Screenshots" could not be parsed as a h3. Anyway, this is fixed.

Seems to be the space character actually not being a space character?